### PR TITLE
Add Plex metadata refresh option

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ targets:
   plex:
     - url: https://plex.domain.tld # URL of your Plex server
       token: XXXX # Plex API Token
+      refresh-metadata: false # Whether to refresh all the metadata in the associated library
       rewrite:
         - from: /mnt/unionfs/Media/ # local file system
           to: /data/ # path accessible by the Plex docker container (if applicable)
@@ -410,6 +411,7 @@ There are a couple of things to take note of in the config:
 
 - URL. The URL can link to the docker container directly, the localhost or a reverse proxy sitting in front of Plex.
 - Token. We need a Plex API Token to make requests on your behalf. [This article](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/) should help you out.
+- Refresh Metadata. If you've added external subtitle files, Plex won't pick up on them without a metadata refresh.  This forces Plex to do that. Defaults to false.
 - Rewrite. If Plex is not running on the host OS, but in a Docker container (or Autoscan is running in a Docker container), then you need to rewrite paths accordingly. Check out our [rewriting section](#rewriting-paths) for more info.
 
 ### Emby
@@ -525,6 +527,7 @@ targets:
   plex:
     - url: https://plex.domain.tld # URL of your Plex server
       token: XXXX # Plex API Token
+      refresh-metadata: true # Force metadata refresh to pick up subtitles
       rewrite:
         - from: /mnt/unionfs/Media/ # local file system
           to: /data/ # path accessible by the Plex docker container (if applicable)

--- a/targets/plex/api.go
+++ b/targets/plex/api.go
@@ -146,7 +146,7 @@ func (c apiClient) Libraries() ([]library, error) {
 	return libraries, nil
 }
 
-func (c apiClient) Scan(path string, libraryID int) error {
+func (c apiClient) Scan(path string, libraryID int, refreshMetadata bool) error {
 	reqURL := autoscan.JoinURL(c.baseURL, "library", "sections", strconv.Itoa(libraryID), "refresh")
 	req, err := http.NewRequest("GET", reqURL, nil)
 	if err != nil {
@@ -155,6 +155,11 @@ func (c apiClient) Scan(path string, libraryID int) error {
 
 	q := url.Values{}
 	q.Add("path", path)
+	if refreshMetadata {
+		// Unfortunately, this needs to be a forced full metadata refresh,
+		// as Plex sometimes ignores un-forced refreshes
+		q.Add("force", "1")
+	}
 	req.URL.RawQuery = q.Encode()
 
 	res, err := c.do(req)

--- a/targets/plex/plex.go
+++ b/targets/plex/plex.go
@@ -11,17 +11,19 @@ import (
 )
 
 type Config struct {
-	URL            string             `yaml:"url"`
-	Token          string             `yaml:"token"`
-	Rewrite        []autoscan.Rewrite `yaml:"rewrite"`
-	Verbosity      string             `yaml:"verbosity"`
-	SlashDirection string             `yaml:"slash-direction"`
+	URL             string             `yaml:"url"`
+	Token           string             `yaml:"token"`
+	RefreshMetadata bool               `yaml:"refresh-metadata"`
+	Rewrite         []autoscan.Rewrite `yaml:"rewrite"`
+	Verbosity       string             `yaml:"verbosity"`
+	SlashDirection  string             `yaml:"slash-direction"`
 }
 
 type target struct {
-	url       string
-	token     string
-	libraries []library
+	url             string
+	token           string
+	refreshMetadata bool
+	libraries       []library
 
 	log     zerolog.Logger
 	rewrite autoscan.Rewriter
@@ -60,9 +62,10 @@ func New(c Config) (autoscan.Target, error) {
 		Msg("Retrieved libraries")
 
 	return &target{
-		url:       c.URL,
-		token:     c.Token,
-		libraries: libraries,
+		url:             c.URL,
+		token:           c.Token,
+		refreshMetadata: c.RefreshMetadata,
+		libraries:       libraries,
 
 		log:     l,
 		rewrite: rewriter,
@@ -97,7 +100,7 @@ func (t target) Scan(scan autoscan.Scan) error {
 
 		l.Trace().Msg("Sending scan request")
 
-		if err := t.api.Scan(scanFolder, lib.ID); err != nil {
+		if err := t.api.Scan(scanFolder, lib.ID, t.refreshMetadata); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This ended up being simpler than I expected to implement.  I updated the readme to describe how it works, but essentially, it adds another option to the Plex config to allow for refreshing the metadata for the library that the media is in.

Unfortunately, it does mean forcing a full refresh of the entire library's metadata, as Plex seems to sometimes ignore the un-forced version (`force=0` vs. `force=1` for the parameter).